### PR TITLE
overlay: Add timekeeper file

### DIFF
--- a/android9/overlay/etc/init/timekeeper.conf
+++ b/android9/overlay/etc/init/timekeeper.conf
@@ -1,0 +1,15 @@
+description "Timekeeper is a utility to keep/restore RTC offset for Qualcomm devices"
+
+start on android
+stop on runlevel [016]
+
+pre-start script
+        sleep 5
+        /usr/bin/timekeeper restore || true
+        echo "pre" >> /var/log/upstart/timekeeper.log
+end script
+
+post-stop script
+        /usr/bin/timekeeper store || true
+        echo "post" >> /var/log/upstart/timekeeper.log
+end script


### PR DESCRIPTION
Timekeeper is a utility to keep/restore RTC offset for Qualcomm devices.